### PR TITLE
Continue child task execution after parent exception for wait and wait_any types

### DIFF
--- a/src/transwarp.h
+++ b/src/transwarp.h
@@ -597,7 +597,7 @@ struct call_with_futures_impl<transwarp::wait_type, true, total, n...> {
     }
     template<typename T, typename... Args>
     static void wait(const T& arg, const Args& ...args) {
-        arg.get();
+        arg.wait();
         wait(args...);
     }
     static void wait() {}
@@ -614,7 +614,7 @@ struct call_with_futures_impl<transwarp::wait_any_type, true, total, n...> {
     static bool wait(const T& arg, const Args& ...args) {
         const auto status = arg.wait_for(std::chrono::microseconds(1));
         if (status == std::future_status::ready) {
-            arg.get();
+            arg.wait();
             return true;
         }
         return wait(args...);


### PR DESCRIPTION
As wait and wait_any don't take parents' results, execution should continue. This
allows for a parent.get() in the child task to also handle error/exception cases.